### PR TITLE
[#12][UI] As a user, I can see the Home page display on different screen size adaptively 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.31'
+        kotlinCompilerVersion '1.6.0'
     }
     packagingOptions {
         resources {
@@ -62,6 +62,8 @@ dependencies {
     implementation "androidx.activity:activity-compose:1.4.0"
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.0-rc02"
     implementation "com.google.accompanist:accompanist-flowlayout:0.22.1-rc"
+
+    implementation "androidx.window:window:1.0.0"
 
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.navigation.compose.rememberNavController
 import co.nimblehq.compose.ecommerce.ui.bottomnavigationbar.BottomNavigationBar
 import co.nimblehq.compose.ecommerce.ui.bottomnavigationbar.Navigation
 import co.nimblehq.compose.ecommerce.ui.bottomnavigationbar.NavigationItem
+import co.nimblehq.compose.ecommerce.utils.WindowSize
+import co.nimblehq.compose.ecommerce.utils.rememberWindowSizeClass
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,14 +25,15 @@ class MainActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, true)
 
         setContent {
-            MainScreen()
+            val windowSize = rememberWindowSizeClass()
+            MainScreen(windowSize)
         }
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun MainScreen() {
+fun MainScreen(windowSize: WindowSize) {
     val navController = rememberNavController()
     val tabItems = listOf(
         NavigationItem.Home,
@@ -43,7 +46,7 @@ fun MainScreen() {
     ) { innerPadding ->
         // Fix the BottomNavigation bar overlap the content https://stackoverflow.com/a/66574166
         Box(modifier = Modifier.padding(innerPadding)) {
-            Navigation(navController)
+            Navigation(navController, windowSize)
         }
     }
 }
@@ -51,5 +54,5 @@ fun MainScreen() {
 @Preview(showBackground = true)
 @Composable
 fun MainScreenPreview() {
-    MainScreen()
+//    MainScreen(windowSizeClass)
 }

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/bottomnavigationbar/Navigation.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/bottomnavigationbar/Navigation.kt
@@ -10,17 +10,18 @@ import co.nimblehq.compose.ecommerce.ui.screen.account.AccountScreen
 import co.nimblehq.compose.ecommerce.ui.screen.home.HomeScreen
 import co.nimblehq.compose.ecommerce.ui.screen.product.ProductScreen
 import co.nimblehq.compose.ecommerce.ui.screen.search.SearchScreen
+import co.nimblehq.compose.ecommerce.utils.WindowSize
 
 @ExperimentalFoundationApi
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun Navigation(navHostController: NavHostController) {
+fun Navigation(navHostController: NavHostController, windowSize: WindowSize) {
     NavHost(
         navController = navHostController,
         startDestination = NavigationItem.Home.route
     ) {
         composable(NavigationItem.Home.route) {
-            HomeScreen()
+            HomeScreen(windowSize)
         }
         composable(NavigationItem.Search.route) {
             SearchScreen()

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/category/Categories.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/category/Categories.kt
@@ -10,29 +10,51 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.nimblehq.compose.ecommerce.model.Category
 import co.nimblehq.compose.ecommerce.ui.theme.AppTextStyle
+import com.google.accompanist.flowlayout.FlowMainAxisAlignment
+import com.google.accompanist.flowlayout.FlowRow
+import com.google.accompanist.flowlayout.SizeMode
 
 @Composable
 fun Categories(
+    horizontalScroll: Boolean,
+    maxWidth: Dp,
     categories: List<Category>
 ) {
-    LazyRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 12.dp, bottom = 20.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp), // Similar clipToPadding
-        horizontalArrangement = Arrangement.spacedBy(8.dp) // Space between items
-    ) {
-        items(categories) { category ->
-            CategoryItem(category)
+    if (horizontalScroll) {
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp, bottom = 20.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp), // Similar clipToPadding
+            horizontalArrangement = Arrangement.spacedBy(8.dp) // Space between items
+        ) {
+            items(categories) { category ->
+                CategoryHorizontalItem(category)
+            }
+        }
+    } else {
+        val itemPadding = 16.dp
+        val itemMaxWidth = (maxWidth - (itemPadding * 2)) / 2
+        FlowRow(
+            mainAxisSize = SizeMode.Expand,
+            mainAxisAlignment = FlowMainAxisAlignment.SpaceEvenly
+        ) {
+            categories.forEach { category ->
+                CategoryVerticalItem(
+                    Modifier.requiredWidth(itemMaxWidth),
+                    category
+                )
+            }
         }
     }
 }
 
 @Composable
-fun CategoryItem(
+fun CategoryHorizontalItem(
     category: Category
 ) {
     Column(
@@ -48,6 +70,30 @@ fun CategoryItem(
 
         Text(
             modifier = Modifier.padding(top = 8.dp, bottom = 12.dp),
+            text = category.name,
+            style = AppTextStyle.category
+        )
+    }
+}
+
+@Composable
+fun CategoryVerticalItem(
+    modifier: Modifier,
+    category: Category
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .clickable(onClick = {/* TODO */ })
+    ) {
+        Image(
+            modifier = modifier,
+            painter = painterResource(id = category.image),
+            contentDescription = null
+        )
+
+        Text(
+            modifier = modifier,
             text = category.name,
             style = AppTextStyle.category
         )

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/collection/Collection.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/collection/Collection.kt
@@ -1,0 +1,157 @@
+package co.nimblehq.compose.ecommerce.ui.collection
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import co.nimblehq.compose.ecommerce.R
+import co.nimblehq.compose.ecommerce.model.categories
+import co.nimblehq.compose.ecommerce.ui.category.Categories
+import co.nimblehq.compose.ecommerce.ui.theme.AppTextStyle
+import co.nimblehq.compose.ecommerce.ui.theme.Blue
+import co.nimblehq.compose.ecommerce.ui.theme.Purple600
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun Collection(
+    showOnePanel: Boolean
+) {
+    val itemMaxWidth = (LocalConfiguration.current.screenWidthDp.dp) / 2
+    if (showOnePanel) {
+        // Suggested for you
+        SuggestedForYouCard(Modifier.fillMaxWidth())
+        // Category
+        Categories(horizontalScroll = true, maxWidth = Dp.Infinity, categories = categories)
+    } else {
+        Row {
+            // Suggested for you
+            SuggestedForYouCard(Modifier.width(itemMaxWidth))
+            // Category
+            Categories(false, maxWidth = itemMaxWidth, categories = categories)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SuggestedForYouCard(modifier: Modifier) {
+    val shape = RoundedCornerShape(12.dp)
+
+    ConstraintLayout(
+        modifier = modifier
+            .height(386.dp)
+            .padding(horizontal = 16.dp)
+            .clip(shape)
+            .background(Blue)
+    ) {
+        val (tvSuggestForYou, tvCollection, tvPrice, btShop, sDivider, ivShirt, tvPoly) = createRefs()
+
+        // FIXME Correct the image to match design
+        Image(
+            modifier = Modifier
+                .constrainAs(ivShirt) {
+                    start.linkTo(parent.start)
+                    top.linkTo(parent.top)
+                }
+                .size(419.dp, 378.dp)
+                .padding(top = 92.dp, start = 32.dp),
+            painter = painterResource(id = R.drawable.ic_shirt),
+            contentDescription = "collection"
+        )
+
+        Text(
+            modifier = Modifier
+                .constrainAs(tvSuggestForYou) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                }
+                .padding(top = 16.dp, start = 16.dp),
+            text = stringResource(R.string.home_suggested_for_you),
+            style = AppTextStyle.tagline
+        )
+
+        Text(
+            modifier = Modifier
+                .constrainAs(tvCollection) {
+                    top.linkTo(tvSuggestForYou.bottom)
+                    start.linkTo(tvSuggestForYou.start)
+                }
+                .padding(top = 4.dp, start = 16.dp, end = 16.dp),
+            text = stringResource(R.string.home_collection),
+            style = AppTextStyle.collection
+        )
+
+        // Work around to display the divider with padding
+        Column(modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .constrainAs(sDivider) {
+                bottom.linkTo(btShop.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+            }
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .background(Color.White.copy(alpha = 0.33f))
+                    .height(0.5.dp)
+                    .fillMaxWidth() // FIXME Padding horizontal doesn't work
+            )
+        }
+
+        Text(
+            modifier = Modifier
+                .constrainAs(tvPoly) {
+                    bottom.linkTo(tvPrice.top)
+                    start.linkTo(tvPrice.start)
+                }
+                .padding(start = 16.dp),
+            text = stringResource(R.string.home_product_name),
+            style = AppTextStyle.productName
+        )
+
+        Text(
+            modifier = Modifier
+                .constrainAs(tvPrice) {
+                    bottom.linkTo(parent.bottom)
+                    start.linkTo(parent.start)
+                }
+                .padding(start = 16.dp, bottom = 16.dp),
+            text = stringResource(R.string.home_product_price),
+            style = AppTextStyle.productPrice
+        )
+
+        Surface(
+            modifier = Modifier
+                .constrainAs(btShop) {
+                    bottom.linkTo(parent.bottom)
+                    end.linkTo(parent.end)
+                }
+                .padding(16.dp),
+            color = Purple600,
+            shape = RoundedCornerShape(17.dp),
+            role = Role.Button,
+            onClick = { /*TODO*/ }
+        ) {
+            Text(
+                text = stringResource(R.string.home_action_shop),
+                style = AppTextStyle.shop,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 5.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/home/Home.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/home/Home.kt
@@ -2,39 +2,35 @@ package co.nimblehq.compose.ecommerce.ui.screen.home
 
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.BadgeBox
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.BadgedBox
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import co.nimblehq.compose.ecommerce.R
-import co.nimblehq.compose.ecommerce.model.categories
 import co.nimblehq.compose.ecommerce.model.mockPopularProducts
-import co.nimblehq.compose.ecommerce.ui.category.Categories
+import co.nimblehq.compose.ecommerce.ui.collection.Collection
 import co.nimblehq.compose.ecommerce.ui.product.Products
 import co.nimblehq.compose.ecommerce.ui.theme.AppTextStyle
-import co.nimblehq.compose.ecommerce.ui.theme.Blue
-import co.nimblehq.compose.ecommerce.ui.theme.Purple600
 import co.nimblehq.compose.ecommerce.ui.theme.Red
+import co.nimblehq.compose.ecommerce.utils.WindowSize
 
 @ExperimentalFoundationApi
 @ExperimentalMaterialApi
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun HomeScreen() {
-    val shape = RoundedCornerShape(12.dp)
+fun HomeScreen(windowSize: WindowSize) {
+    val isExpandedScreen = windowSize == WindowSize.Expanded
 
     Column(
         modifier = Modifier
@@ -61,18 +57,21 @@ fun HomeScreen() {
                 style = AppTextStyle.title
             )
 
-            BadgeBox(
+            BadgedBox(
                 modifier = Modifier.constrainAs(bbProfile) {
                     end.linkTo(parent.end)
                     bottom.linkTo(parent.bottom)
                 },
-                badgeContent = {
+                badge = {
                     Text(
-                        "3",
+                        modifier = Modifier
+                            .background(color = Red, shape = CircleShape)
+                            .defaultMinSize(18.dp),
+                        text = "3",
+                        textAlign = TextAlign.Center,
                         style = AppTextStyle.badge
                     )
-                },
-                backgroundColor = Red
+                }
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.ic_profile),
@@ -82,114 +81,8 @@ fun HomeScreen() {
             }
         }
 
-        // Collection
-        ConstraintLayout(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(386.dp)
-                .padding(horizontal = 16.dp)
-                .clip(shape)
-                .background(Blue)
-        ) {
-            val (tvSuggestForYou, tvCollection, tvPrice, btShop, sDivider, ivShirt, tvPoly) = createRefs()
-
-            // FIXME Correct the image to match design
-            Image(
-                modifier = Modifier
-                    .constrainAs(ivShirt) {
-                        start.linkTo(parent.start)
-                        top.linkTo(parent.top)
-                    }
-                    .size(419.dp, 378.dp)
-                    .padding(top = 92.dp, start = 32.dp),
-                painter = painterResource(id = R.drawable.ic_shirt),
-                contentDescription = "collection"
-            )
-
-            Text(
-                modifier = Modifier
-                    .constrainAs(tvSuggestForYou) {
-                        top.linkTo(parent.top)
-                        start.linkTo(parent.start)
-                    }
-                    .padding(top = 16.dp, start = 16.dp),
-                text = stringResource(R.string.home_suggested_for_you),
-                style = AppTextStyle.tagline
-            )
-
-            Text(
-                modifier = Modifier
-                    .constrainAs(tvCollection) {
-                        top.linkTo(tvSuggestForYou.bottom)
-                        start.linkTo(tvSuggestForYou.start)
-                    }
-                    .padding(top = 4.dp, start = 16.dp, end = 16.dp),
-                text = stringResource(R.string.home_collection),
-                style = AppTextStyle.collection
-            )
-
-            // Work around to display the divider with padding
-            Column(modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .constrainAs(sDivider) {
-                    bottom.linkTo(btShop.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-            ) {
-                Spacer(
-                    modifier = Modifier
-                        .background(Color.White.copy(alpha = 0.33f))
-                        .height(0.5.dp)
-                        .fillMaxWidth() // FIXME Padding horizontal doesn't work
-                )
-            }
-
-            Text(
-                modifier = Modifier
-                    .constrainAs(tvPoly) {
-                        bottom.linkTo(tvPrice.top)
-                        start.linkTo(tvPrice.start)
-                    }
-                    .padding(start = 16.dp),
-                text = stringResource(R.string.home_product_name),
-                style = AppTextStyle.productName
-            )
-
-            Text(
-                modifier = Modifier
-                    .constrainAs(tvPrice) {
-                        bottom.linkTo(parent.bottom)
-                        start.linkTo(parent.start)
-                    }
-                    .padding(start = 16.dp, bottom = 16.dp),
-                text = stringResource(R.string.home_product_price),
-                style = AppTextStyle.productPrice
-            )
-
-            Surface(
-                modifier = Modifier
-                    .constrainAs(btShop) {
-                        bottom.linkTo(parent.bottom)
-                        end.linkTo(parent.end)
-                    }
-                    .padding(16.dp),
-                color = Purple600,
-                shape = RoundedCornerShape(17.dp),
-                role = Role.Button,
-                onClick = { /*TODO*/ }
-            ) {
-                Text(
-                    text = stringResource(R.string.home_action_shop),
-                    style = AppTextStyle.shop,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 5.dp)
-                )
-            }
-        }
-
-        // Category
-        Categories(categories)
+        // Suggested for you Collection
+        Collection(showOnePanel = !isExpandedScreen)
 
         // Popular products
         Products(
@@ -205,5 +98,5 @@ fun HomeScreen() {
 @Preview(showBackground = true)
 @Composable
 fun HomeScreenPreview() {
-    HomeScreen()
+//    HomeScreen(windowSizeClass)
 }

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/utils/WindowSize.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/utils/WindowSize.kt
@@ -1,0 +1,66 @@
+package co.nimblehq.compose.ecommerce.utils
+
+import android.app.Activity
+import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.toComposeRect
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.window.layout.WindowMetricsCalculator
+
+// Reference: https://github.com/android/compose-samples/blob/main/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
+/**
+ * Opinionated set of viewport breakpoints
+ *     - Compact: Most phones in portrait mode
+ *     - Medium: Most foldables and tablets in portrait mode
+ *     - Expanded: Most tablets in landscape mode
+ *
+ * More info: https://material.io/archive/guidelines/layout/responsive-ui.html
+ */
+enum class WindowSize { Compact, Medium, Expanded }
+
+/**
+ * Remembers the [WindowSize] class for the window corresponding to the current window metrics.
+ */
+@Composable
+fun Activity.rememberWindowSizeClass(): WindowSize {
+    // Get the size (in pixels) of the window
+    val windowSize = rememberWindowSize()
+
+    // Convert the window size to [Dp]
+    val windowDpSize = with(LocalDensity.current) {
+        windowSize.toDpSize()
+    }
+
+    // Calculate the window size class
+    return getWindowSizeClass(windowDpSize)
+}
+
+/**
+ * Remembers the [Size] in pixels of the window corresponding to the current window metrics.
+ */
+@Composable
+private fun Activity.rememberWindowSize(): Size {
+    val configuration = LocalConfiguration.current
+    // WindowMetricsCalculator implicitly depends on the configuration through the activity,
+    // so re-calculate it upon changes.
+    val windowMetrics = remember(configuration) {
+        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(this)
+    }
+    return windowMetrics.bounds.toComposeRect().size
+}
+
+/**
+ * Partitions a [DpSize] into a enumerated [WindowSize] class.
+ */
+@VisibleForTesting
+fun getWindowSizeClass(windowDpSize: DpSize): WindowSize = when {
+    windowDpSize.width < 0.dp -> throw IllegalArgumentException("Dp value cannot be negative")
+    windowDpSize.width < 600.dp -> WindowSize.Compact
+    windowDpSize.width < 840.dp -> WindowSize.Medium
+    else -> WindowSize.Expanded
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.5'
+        compose_version = '1.1.0-rc01'
     }
     repositories {
         google()
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
https://github.com/nimblehq/jetpack-compose-ecommerce/issues/12

## What happened 👀

On the large screen-width, the UI would be displayed adaptively to the users to show more content and nicely
 
## Insight 📝

- Update compose version to use WindowManager and Kotlin version for compatible
- Add WindowSize class with extension to handle screen sizes (Reference: [JetNews](https://github.com/android/compose-samples/blob/main/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt) project)
- Refactor the compose UI on the Home screen to support adaptive layouts
 
## Proof Of Work 📹

- Device: Pixel C tablet

| Before      | After |
| ----------- | ----------- |
| <img src="https://user-images.githubusercontent.com/6950766/155375582-bb059ad9-3fdc-4338-a345-ad2a920fe361.png" width=450/>      | <img src="https://user-images.githubusercontent.com/6950766/155375567-06f63aac-61c2-496d-a01c-453ca3af2cf3.png" width=450/>       |