### PR TITLE
[#16][UI] As a user, I can see the list of products select from the Search page

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/ecommerce/EcommerceAppState.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/EcommerceAppState.kt
@@ -26,8 +26,15 @@ class EcommerceAppState(
     private val bottomBarRoutes = bottomNavItems.map { it.route }
 
     val shouldShowBottomBar: Boolean
-        @Composable get() = navController
-            .currentBackStackEntryAsState().value?.destination?.route in bottomBarRoutes
+        @Composable get() {
+            val route = navController
+                .currentBackStackEntryAsState().value?.destination?.route.orEmpty()
+            val isTabItem = route in bottomBarRoutes
+            val isDetailPage = bottomBarRoutes.filter { tabRoute ->
+                route.startsWith(tabRoute, true)
+            }.isNullOrEmpty().not()
+            return isTabItem || isDetailPage
+        }
 
     val currentRoute: String?
         get() = navController.currentDestination?.route
@@ -54,6 +61,18 @@ class EcommerceAppState(
         // In order to discard duplicated navigation events, we check the Lifecycle
         if (from.lifecycleIsResumed()) {
             navController.navigate("${NavigationRoute.PRODUCT_DETAILS_ROUTE}/$productId")
+        }
+    }
+
+    fun navigateToSearchResult(query: String, from: NavBackStackEntry) {
+        if (from.lifecycleIsResumed()) {
+            navController.navigate("${NavigationRoute.SEARCH_RESULT_ROUTE}/$query")
+        }
+    }
+
+    fun navigateToFilters(from: NavBackStackEntry) {
+        if (from.lifecycleIsResumed()) {
+            navController.navigate(NavigationRoute.FILTERS_ROUTE)
         }
     }
 }

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/MainActivity.kt
@@ -55,6 +55,8 @@ fun MainScreen(windowSize: WindowSize) {
             ) {
                 appNavGraph(
                     onProductSelected = appState::navigateToProductDetail,
+                    onSearchProduct = appState::navigateToSearchResult,
+                    onFilterClick = appState::navigateToFilters,
                     upPress = appState::upPress,
                     windowSize = windowSize
                 )

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/model/Product.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/model/Product.kt
@@ -81,3 +81,30 @@ val mockMoreCubesProducts = listOf(
                 image = R.drawable.ic_shirt_honey_cube
         )
 )
+
+val mockSearchResultProducts = listOf(
+        Product(
+                id = 1,
+                name = "Pink Cube",
+                price = 10000,
+                image = R.drawable.ic_shirt_pink_cube
+        ),
+        Product(
+                id = 2,
+                name = "Gray Cube",
+                price = 10000,
+                image = R.drawable.ic_shirt_gray_cube
+        ),
+        Product(
+                id = 3,
+                name = "Indigo Cube",
+                price = 8000,
+                image = R.drawable.ic_shirt_indigo_cube
+        ),
+        Product(
+                id = 4,
+                name = "Honey Cube",
+                price = 8000,
+                image = R.drawable.ic_shirt_honey_cube
+        )
+)

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/bottomnavigationbar/BottomNavigationBar.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/bottomnavigationbar/BottomNavigationBar.kt
@@ -28,17 +28,19 @@ fun BottomNavigationBar(
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
         items.forEach { item ->
+            val isSelected =
+                (currentRoute == item.route) || (currentRoute?.startsWith(item.route) ?: false)
             BottomNavigationItem(
                 icon = {
                     BottomNavigationItemIcon(
                         item = item,
-                        selected = currentRoute == item.route
+                        selected = isSelected
                     )
                 },
                 selectedContentColor = Purple600,
                 unselectedContentColor = WhiteTrans25,
                 alwaysShowLabel = false,
-                selected = currentRoute == item.route,
+                selected = isSelected,
                 onClick = { navigateToRoute(item.route) }
             )
         }

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/filter/Filters.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/filter/Filters.kt
@@ -24,9 +24,10 @@ import co.nimblehq.compose.ecommerce.ui.theme.Gray5
 import co.nimblehq.compose.ecommerce.ui.theme.Purple600
 
 @ExperimentalFoundationApi
-@Preview
 @Composable
-fun Filters() {
+fun Filters(
+    upPress: () -> Unit
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -38,7 +39,7 @@ fun Filters() {
                     )
                 },
                 navigationIcon = {
-                    TextButton(onClick = {}) {
+                    TextButton(onClick = upPress) {
                         Text(
                             text = stringResource(id = R.string.filters_close)
                         )
@@ -131,14 +132,14 @@ fun Filters() {
 fun SortByItem(
     radioOptions: List<Pair<String, String>>
 ) {
-    val (selectedOption, onOptionSelected) = remember { mutableStateOf(radioOptions[0].first) }
-    radioOptions.forEach { (title, description) ->
+    val (selectedOption, onOptionSelected) = remember { mutableStateOf(0) }
+    radioOptions.forEachIndexed { index, (title, description) ->
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .selectable(
-                    selected = (title == selectedOption),
-                    onClick = { onOptionSelected(title) }
+                    selected = (index == selectedOption),
+                    onClick = { onOptionSelected(index) }
                 )
         ) {
             Text(
@@ -166,9 +167,9 @@ fun SortByItem(
                     selectedColor = Purple600,
                     unselectedColor = Purple600
                 ),
-                selected = (title == selectedOption),
+                selected = (index == selectedOption),
                 onClick = {
-                    onOptionSelected(title)
+                    onOptionSelected(index)
                 }
             )
         }
@@ -211,3 +212,11 @@ fun FilterByItem(
         thickness = 1.dp
     )
 }
+
+@ExperimentalFoundationApi
+@Preview
+@Composable
+fun FiltersPreview() {
+    Filters {}
+}
+

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/search/Search.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/search/Search.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -18,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,7 +32,9 @@ import co.nimblehq.compose.ecommerce.ui.theme.Gray2
 
 @ExperimentalFoundationApi
 @Composable
-fun SearchScreen() {
+fun SearchScreen(
+    onSearchProduct: (String) -> Unit
+) {
 
     Column(
         modifier = Modifier
@@ -79,6 +84,10 @@ fun SearchScreen() {
                         contentDescription = null // decorative element
                     )
                 },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(
+                    onSearch = { onSearchProduct(inputValue.value.text) }
+                ),
                 textStyle = AppTextStyle.searchField
             )
 
@@ -91,7 +100,11 @@ fun SearchScreen() {
         }
 
         // Shapes
-        Shapes(columnsPerRow = 2, shapes = mockShapes)
+        Shapes(
+            columnsPerRow = 2,
+            shapes = mockShapes,
+            onShapeClick = { shapeName -> onSearchProduct(shapeName) }
+        )
     }
 }
 

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/search/SearchResult.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/screen/search/SearchResult.kt
@@ -1,0 +1,118 @@
+package co.nimblehq.compose.ecommerce.ui.screen.search
+
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import co.nimblehq.compose.ecommerce.R
+import co.nimblehq.compose.ecommerce.model.mockSearchResultProducts
+import co.nimblehq.compose.ecommerce.ui.product.ProductItem
+import co.nimblehq.compose.ecommerce.ui.theme.AppTextStyle
+import com.google.accompanist.flowlayout.FlowMainAxisAlignment
+import com.google.accompanist.flowlayout.FlowRow
+import com.google.accompanist.flowlayout.SizeMode
+
+@ExperimentalFoundationApi
+@Composable
+fun SearchResultScreen(
+    searchKey: String,
+    columnsPerRow: Int = 2,
+    onProductClick: (Long) -> Unit,
+    onFilterClick: () -> Unit,
+    upPress: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = upPress) {
+                        Icon(Icons.Outlined.ArrowBack, null)
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        }
+    ) {
+        val itemPadding = 16.dp
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .background(color = Color.White)
+                .padding(horizontal = itemPadding)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 30.dp)
+            ) {
+                Text(
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    text = searchKey,
+                    style = AppTextStyle.searchResultHeader
+                )
+
+                Text(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .clickable {
+                            onFilterClick()
+                        },
+                    text = stringResource(R.string.filters_applied, 1),
+                    style = AppTextStyle.searchResultFilter
+                )
+            }
+
+            val products = mockSearchResultProducts
+
+            // Workaround solution: https://medium.com/tech-takeaways/scrollable-grid-view-with-jetpack-compose-aed9f2b9c382
+            val itemMaxWidth =
+                (LocalConfiguration.current.screenWidthDp.dp - (itemPadding * 2)) / columnsPerRow
+            FlowRow(
+                mainAxisSize = SizeMode.Expand,
+                mainAxisAlignment = FlowMainAxisAlignment.SpaceEvenly
+            ) {
+                products.forEachIndexed { index, product ->
+                    val modifier = if (index % 2 == 0) {
+                        Modifier
+                            .requiredWidth(itemMaxWidth)
+                            .padding(end = 8.dp)
+                    } else {
+                        Modifier
+                            .requiredWidth(itemMaxWidth)
+                            .padding(start = 8.dp)
+                    }
+                    ProductItem(
+                        modifier = modifier,
+                        product = product,
+                        onProductClick = onProductClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@ExperimentalFoundationApi
+@Composable
+@Preview
+fun SearchResultScreenPreview() {
+    SearchResultScreen(
+        searchKey = "Cube",
+        columnsPerRow = 2,
+        onProductClick = {},
+        onFilterClick = {},
+        upPress = {}
+    )
+}

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/shape/Shapes.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/shape/Shapes.kt
@@ -2,6 +2,7 @@ package co.nimblehq.compose.ecommerce.ui.shape
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -27,7 +28,8 @@ import com.google.accompanist.flowlayout.SizeMode
 @Composable
 fun Shapes(
     columnsPerRow: Int,
-    shapes: List<Shape>
+    shapes: List<Shape>,
+    onShapeClick: (String) -> Unit
 ) {
     val itemPadding = 16.dp
     Column(
@@ -51,7 +53,9 @@ fun Shapes(
                         .padding(start = 8.dp)
                 }
                 ShapeItem(
-                    modifier = modifier,
+                    modifier = modifier.clickable {
+                        onShapeClick(shape.name)
+                    },
                     shape
                 )
             }
@@ -66,7 +70,7 @@ fun ShapesPreview() {
     Shapes(
         columnsPerRow = 2,
         shapes = mockShapes
-    )
+    ) {}
 }
 
 @Composable

--- a/app/src/main/java/co/nimblehq/compose/ecommerce/ui/theme/Style.kt
+++ b/app/src/main/java/co/nimblehq/compose/ecommerce/ui/theme/Style.kt
@@ -195,4 +195,18 @@ object AppTextStyle {
         textAlign = TextAlign.Center,
         fontSize = 17.sp,
     )
+
+    val searchResultHeader = TextStyle(
+        color = Gray,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        fontSize = 34.sp,
+    )
+
+    val searchResultFilter = TextStyle(
+        color = Purple600,
+        fontWeight = FontWeight.Normal,
+        textAlign = TextAlign.Center,
+        fontSize = 17.sp,
+    )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="settings_log_out">Log out</string>
 
     <string name="filters_title">Filters</string>
+    <string name="filters_applied">Filter (%d)</string>
     <string name="filters_close">Close</string>
     <string name="filters_reset">Reset</string>
     <string name="filters_sort_by">Sort by</string>


### PR DESCRIPTION
https://github.com/nimblehq/jetpack-compose-ecommerce/issues/16

## What happened 👀

Whenever user selects the Search tab on the bottom navigation bar, the content will be shown to the user.
 
## Insight 📝

- Add Search Result screen
- Navigate to Filters screen from Search Result
 
## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/162580985-b639f340-ba20-45bc-acc6-678b20a93943.mp4
